### PR TITLE
Improve setup docs and auto-install deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ A: 可能原因：
 - 网络连接问题
 - B站服务器问题
 
+### Q: 扫码登录时页面不显示二维码？
+A: 请确认已执行 `npm install` 安装依赖并通过 `npm run dev` 或 `npm start` 启动后端服务。本项目未包含 `node_modules` 目录，如未安装依赖将导致 `/auth/qrkey` 接口无法访问，从而无法获取二维码。
+
 ### Q: 如何获取B站用户ID？
 A: 访问用户主页，URL中的数字就是用户ID
 例如：`https://space.bilibili.com/123456` 中的 `123456`

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "沉浸式哔哩哔哩收藏夹播放器",
   "main": "server.js",
   "scripts": {
+    "prestart": "node scripts/checkDeps.js",
     "start": "node server.js",
     "dev": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/scripts/checkDeps.js
+++ b/scripts/checkDeps.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const { execSync } = require('child_process');
+
+const deps = ['express', 'axios', 'cors', 'express-session', 'bilibili-api'];
+const missing = deps.filter(dep => !fs.existsSync(`node_modules/${dep}`));
+
+if (missing.length > 0) {
+  console.log('Missing dependencies:', missing.join(', '));
+  console.log('Installing dependencies...');
+  try {
+    execSync('npm install', { stdio: 'inherit' });
+  } catch (e) {
+    console.error('Automatic install failed. Please run "npm install" manually.');
+  }
+}


### PR DESCRIPTION
## Summary
- add a prestart script to automatically install missing dependencies
- document how to resolve missing QR code issue in the FAQ

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686907a2cb14832a98401b92281c4022